### PR TITLE
Example ViewOutlineProvider should be a static class

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This example clips the outline of a View as a rounded rectangle by defining a cl
  implements ViewOutlineProvider by following code:
 
 ```java
-private class ClipOutlineProvider extends ViewOutlineProvider {
+private static class ClipOutlineProvider extends ViewOutlineProvider {
     @Override
     public void getOutline(View view, Outline outline) {
         final int margin = Math.min(view.getWidth(), view.getHeight()) / 10;


### PR DESCRIPTION
Let's encourage people to use static inner classes to avoid leaking references to the container class.
